### PR TITLE
Adapt receiver to Loki data format

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,17 @@
+---
+dependencies: []
+
+galaxy_info:
+  role_name: otel_journald_role
+  author: "Arnaud Bergeron, Olivier Breuleux"
+  description: Export journald entries to Loki endpoint through OpenTelemetry
+  company: "MILA"
+  license: "MIT"
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,17 +3,57 @@ otel_collector_service_user: "{{ otel_user }}"
 otel_collector_receivers:
   journald:
     units: "{{ otel_units }}"
+    operators:
+    # Loki maps resource.service.name to index service_name
+    - type: copy
+      from: body._SYSTEMD_UNIT
+      to: resource["service.name"]
+    # If UNIT is defined, we'll use that instead
+    # e.g. when _SYSTEMD_UNIT is init.scope
+    - type: copy
+      from: body.UNIT
+      to: resource["service.name"]
+    # Loki maps resource.service.instance.id to index service_instance_id
+    - type: copy
+      from: body._HOSTNAME
+      to: resource["service.instance.id"]
+    # This operator sets severity_number and severity_text, which Loki will map to a level
+    # Partly useless because everything that's logged from stdout has PRIORITY=6
+    - type: severity_parser
+      parse_from: body.PRIORITY
+      mapping:
+        critical:
+          min: 0
+          max: 2
+        error: 3
+        warn: 4
+        info:
+          min: 5
+          max: 6
+        debug: 7
+    # Move the keys in the body to the attributes
+    - type: copy
+      from: body
+      to: attributes.TMP
+    - type: flatten
+      field: attributes.TMP
+    # Use MESSAGE as the body/line for Loki
+    - type: copy
+      from: attributes.MESSAGE
+      to: body
 
 otel_collector_processors:
   batch:
 
 otel_collector_exporters:
-  otlp:
+  otlphttp/logs:
     endpoint: "{{ otel_endpoint }}"
+    tls:
+      insecure: true
 
 otel_collector_service:
   pipelines:
     logs:
       receivers: [journald]
       processors: [batch]
-      exporters: [otlp]
+      exporters: [otlphttp/logs]


### PR DESCRIPTION
* Added `meta/main.yml` because it is required when installing a role using a git reference through `requirements.yml` (needed for deployment).
* Changed the exporter for `otlphttp/logs`, I couldn't make it work otherwise.
* Added a pipeline of operators to the receiver so that Loki will see the proper service_name, service_instance_id and severity level, and show the log message instead of a big JSON blob.

I tested this version on test Loki and Grafana instances created using dev-env and it appears to work well.

In practice, all messages collected for the journal through stdout get PRIORITY=6 (info) unless prefixed with `<N>` (e.g. `<2>ERROR: xyz`), but Loki appears to detect the level based on keywords like WARNING or ERROR, so it shouldn't be a major issue. We may still want to adapt our loggers to output the priority level when `$INVOCATION_ID` is set.
